### PR TITLE
fix: Declaration-only npm package.

### DIFF
--- a/ts_version/Makefile
+++ b/ts_version/Makefile
@@ -12,9 +12,12 @@ build:  # Build the NPM package.
 	cp -a src dist
 	cp tsconfig.json dist/
 	sed -i -e '/"rootDir"/d' dist/tsconfig.json
-	cd dist && npx tsc && cd ..
+	cd dist && npx tsc -d && cd ..
 	rm -rvf dist/__mocks__
-	find dist -depth -regex '.*/specs[/]?.*' -delete
+	find dist -regex '.*/specs[/]?.*' -delete
+	find dist -regex '.*[.]ts' -not -regex ".*[.]d[.]ts" -delete
+	find dist -regex '.*[.]test[.].*' -delete
+	rm dist/tsconfig.json
 	cp package.json README.md ../LICENSE.txt dist/
 
 tarball: build

--- a/ts_version/package-lock.json
+++ b/ts_version/package-lock.json
@@ -1,16 +1,13 @@
 {
-  "name": "shortStuff",
-  "version": "0.0.0",
+  "name": "short-stuff",
+  "version": "1.2.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "shortStuff",
-      "version": "0.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "uuid": "^8.3.2"
-      },
+      "name": "short-stuff",
+      "version": "1.2.0-rc.1",
+      "license": "WTFPL",
       "devDependencies": {
         "@types/jest": "^28.1.5",
         "@types/uuid": "^8.3.4",
@@ -20,6 +17,9 @@
         "jest": "^28.1.3",
         "ts-jest": "^28.0.5",
         "typescript": "^4.7.4"
+      },
+      "peerDependencies": {
+        "uuid": ">=8.3.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4407,6 +4407,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -7819,7 +7820,8 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "peer": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/ts_version/package.json
+++ b/ts_version/package.json
@@ -1,6 +1,6 @@
 {
   "name": "short-stuff",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Short Stuff is a set of helper functions used for generating short unique identifiers, such as those used in YouTube video IDs or in URL shorteners.",
   "main": "index.js",
   "scripts": {
@@ -52,7 +52,7 @@
     "ts-jest": "^28.0.5",
     "typescript": "^4.7.4"
   },
-  "dependencies": {
-    "uuid": "^8.3.2"
+  "peerDependencies": {
+    "uuid": ">=8.3.2"
   }
 }


### PR DESCRIPTION
This PR changes how the NPM publishing works to publish the declaration files rather than the raw TypeScript source, so that any internal type issues caused by new versions of TypeScript do not affect downstream.

It also marks uuid as a peer dependency rather than a dev dependency, which it is.